### PR TITLE
details to install in a virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ instructions here are split out by platform:
 * Others - there are some other Python library dependencies. Run `make
   builddeb` to create a `.deb` package, then install it with `dpkg -i
   mydeb.deb`. This will prompt you regarding any missing dependencies.
+ 
+* If `make builddeb` gives trouble, install in a virtualenv and activate when you need it. Assuming you have virtualenv and virtualenvwrapper run `mkvirtualenv --python=/usr/bin/python3 email2pdf_env` then from within the email2pdf folder `python3 setup.py install`. You just need to activate the new virtualenv with `workon email2pdf_env` and switch it off when you're finished with `deactivate`
 
 ### OS X
 


### PR DESCRIPTION
The other .deb instructions raised some errors and this seemed to be the quickest and cleanest path to get it running on my debian system. Sometimes someone just needs a solution in a rush so having this in the readme could help someone short on time to just get it up and running. The virtualenv of course stops it from dirtying the system python install. I've converted a few emails to pdf already and it worked also with `--headers`. Had previously also installed that dependency with `sudo apt install wkhtmltopdf` but it is already mentioned in the readme. 